### PR TITLE
remove -e flag on install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - python: "2.7"
       install:
-        - pip install -e ".[dev]"
+        - pip install ".[dev]"
       script:
         - pytype -V 2.7 ./script.module.pyxbmct/lib/pyxbmct/
         - python -m unittest2 discover


### PR DESCRIPTION
There is no need to use the -e flag to install in editable mode. Doesn't make sense here, think I just copy pasted without thinking!