### PR TITLE
Python 2 compatible function type hints moved to the correct place

### DIFF
--- a/script.module.pyxbmct/lib/pyxbmct/abstractgrid.py
+++ b/script.module.pyxbmct/lib/pyxbmct/abstractgrid.py
@@ -41,18 +41,18 @@ class AbstractGrid(object if _XBMC4XBOX else with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def getRows(self):
+        # type: () -> int
         """
         Get grid rows count.
         """
-        # type: () -> int
         raise NotImplementedError
 
     @abstractmethod
     def getColumns(self):
+        # type: () -> int
         """
         Get grid columns count.
         """
-        # type: () -> int
         raise NotImplementedError
 
     @abstractmethod
@@ -101,6 +101,7 @@ class AbstractGrid(object if _XBMC4XBOX else with_metaclass(ABCMeta, object)):
         raise NotImplementedError
 
     def placeControl(self, control, row, column, rowspan=1, columnspan=1, pad_x=5, pad_y=5):
+        # type: (xbmcgui.Control, int, int, int, int, int, int) -> None
         """
         Place a control within the window grid layout.
 
@@ -120,7 +121,6 @@ class AbstractGrid(object if _XBMC4XBOX else with_metaclass(ABCMeta, object)):
 
             self.placeControl(self.label, 0, 1)
         """
-        # type: (xbmcgui.Control, int, int, int, int, int, int) -> None
         tile_width = self.getTileWidth()
         tile_height = self.getTileHeight()
         control_x = (self.getGridX() + tile_width * column) + pad_x

--- a/script.module.pyxbmct/lib/pyxbmct/addoncontrols.py
+++ b/script.module.pyxbmct/lib/pyxbmct/addoncontrols.py
@@ -55,6 +55,7 @@ class ControlWithConnectCallback(object if _XBMC4XBOX else with_metaclass(ABCMet
 
     @abstractmethod
     def _connectCallback(self, callback, window):
+        # type: (typing.Callable, xbmcgui.Window) -> typing.Union[bool, typing.Callable]
         """
         Called just before an event is connected to a control.
         If true is returned callback is connected to the control.
@@ -63,7 +64,6 @@ class ControlWithConnectCallback(object if _XBMC4XBOX else with_metaclass(ABCMet
         :param callback: the callback that is to be associated with the control
         :param window: the window on which the connect method was called
         """
-        # type: (typing.Callable, xbmcgui.Window) -> typing.Union[bool, typing.Callable]
         raise NotImplementedError
 
 
@@ -75,6 +75,7 @@ class ControlWithPlacedCallback(object if _XBMC4XBOX else with_metaclass(ABCMeta
 
     @abstractmethod
     def _placedCallback(self, window, row, column, rowspan, columnspan, pad_x, pad_y):
+        # type: (xbmcgui.Window, int, int, int, int, int, int) -> None
         """
         Called after the control has been placed in a Window or Group.
         :param window: the window in which the control has been placed
@@ -85,7 +86,6 @@ class ControlWithPlacedCallback(object if _XBMC4XBOX else with_metaclass(ABCMeta
         :param pad_x: the number of pixels of padding inside the cell around the left and right sides of the control
         :param pad_y: the number of pixels of padding inside the cell around the top and bottom sides of the control
         """
-        # type: (xbmcgui.Window, int, int, int, int, int, int) -> None
         raise NotImplementedError
 
 
@@ -97,11 +97,11 @@ class ControlWithRemovedCallback(object if _XBMC4XBOX else with_metaclass(ABCMet
 
     @abstractmethod
     def _removedCallback(self, window):
+        # type: (xbmcgui.Window) -> None
         """
         Called just before a control is removed from the window
         :param window: The window the control is being removed from
         """
-        # type: (xbmcgui.Window) -> None
         raise NotImplementedError
 
 
@@ -113,12 +113,12 @@ class ControlWithFocusedCallback(object if _XBMC4XBOX else with_metaclass(ABCMet
 
     @abstractmethod
     def _focusedCallback(self):
+        # type: () -> bool
         """
         Called when a control is focused either by manually calling Window.setFocus or
         by the user navigating to it.
         :returns The return value is only used when setFocus is called. If false the control won't be focused on.
         """
-        # type: () -> bool
         raise NotImplementedError
 
 
@@ -152,6 +152,7 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
         raise AddonWindowError("Could not find Control class")
 
     def isEnabled(self):
+        # type: () -> bool
         """
         Determine if a control is enabled or not.
 
@@ -159,13 +160,13 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
 
             enabled = self.isEnabled()
         """
-        # type: () -> bool
         # Test this way so that a constructor is not needed
         # to set the intial values
         return not hasattr(self, "_is_enabled") or self._is_enabled
 
     if _XBMC4XBOX:
         def isVisible(self):
+            # type: () -> bool
             """
             Determine if the control is visible or not.
 
@@ -173,7 +174,6 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
 
                 enabled = self.isVisible()
             """
-            # type: () -> bool
             return not hasattr(self, "_is_visible") or self._is_visible
 
         def getX(self):
@@ -185,6 +185,7 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
             return self.getPosition()[1]
 
         def setVisible(self, is_visible):
+            # type: (bool) -> None
             """
             Set whether the control is visible or not.
 
@@ -194,11 +195,11 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
 
                 self.setVisible(False)
             """
-            # type: (bool) -> None
             self._is_visible = is_visible
             self._getControlClass().setVisible(self, is_visible)
 
     def setEnabled(self, is_enabled):
+        # type: (bool) -> None
         """
         Set whether the control is enabled or not.
 
@@ -208,11 +209,11 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
 
             self.setEnabled(False)
         """
-        # type: (bool) -> None
         self._is_enabled = is_enabled
         self._getControlClass().setEnabled(self, is_enabled)
 
     def getMidpoint(self):
+        # type: () -> typing.Tuple[int, int]
         """
         Get the (x,y) coordinates of the controls midpoint.
 
@@ -220,7 +221,6 @@ class ControlMixin(xbmcgui.Control if TYPE_CHECKING else object):
 
             x, y = self.getMidpoint()
         """
-        # type: () -> typing.Tuple[int, int]
         x = self.getX()
         y = self.getY()
         width = self.getWidth()
@@ -590,17 +590,17 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
         return self.getHeight()
 
     def getRows(self):
+        # type: () -> int
         """
         Get grid rows count.
         """
-        # type: () -> int
         return self._rows
 
     def getColumns(self):
+        # type: () -> int
         """
         Get grid columns count.
         """
-        # type: () -> int
         return self._columns
 
     def addControl(self, control):
@@ -618,6 +618,7 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
         self._window = None
 
     def removeControl(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Remove a control from the window grid layout.
 
@@ -627,12 +628,12 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
 
             self.removeControl(self.label)
         """
-        # type: (xbmcgui.Control) -> None
         # getWindow will throw an error if Group is not placed
         self.getWindow().removeControl(control)
         self._controls.remove(control)
 
     def removeControls(self, controls):
+        # type: (typing.Iterable[xbmcgui.Control]) -> None
         """
         Remove multiple controls from the window grid layout.
 
@@ -642,13 +643,13 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
 
             self.removeControl(self.label)
         """
-        # type: (typing.Iterable[xbmcgui.Control]) -> None
         # Need to copy the list of controls as we are changing
         # its size whilst iterating over it
         for control in list(controls):
             self.removeControl(control)
 
     def removeAllChildren(self):
+        # type: () -> None
         """
         Removes all the Group's children (and all their children) from the window.
 
@@ -656,10 +657,10 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
 
             group.removeAllChildren()
         """
-        # type: () -> None
         self.removeControls(self._controls)
 
     def setVisible(self, is_visible):
+        # type: (bool) -> None
         """
         Sets the group (and it all its current children) to be either visible or invisible.
 
@@ -669,7 +670,6 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
 
             group.setVisible(False)
         """
-        # type: (bool) -> None
         xbmcgui.ControlGroup.setVisible(self, is_visible)
         for control in self._controls:
             control.setVisible(is_visible)
@@ -683,6 +683,7 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
             control.setVisibleCondition(is_visible, allow_hidden_focus)
 
     def setEnabled(self, is_enabled):
+        # type: (bool) -> None
         """
         Sets the group (and it all its current children) to be either enabled or disabled.
 
@@ -692,7 +693,6 @@ class Group(ControlMixin, xbmcgui.ControlGroup, AbstractGrid, ControlWithPlacedC
 
             group.setVisible(setEnabled)
         """
-        # type: (bool) -> None
         xbmcgui.ControlGroup.setEnabled(self, is_enabled)
         for control in self._controls:
             control.setEnabled(is_enabled)

--- a/script.module.pyxbmct/lib/pyxbmct/addonwindow.py
+++ b/script.module.pyxbmct/lib/pyxbmct/addonwindow.py
@@ -75,6 +75,7 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
                        include_invisible=False, controls_subset=None,
                        control_types=(Button, List, RadioButton) if _XBMC4XBOX \
                                else (Button, List, RadioButton, Slider, Edit)):
+        # type: (bool, bool, bool, bool, typing.Iterable[xbmcgui.Control], typing.Tuple[typing.Any, ...]) -> None
         """
         Automatically setup the navigation between controls in the Window
 
@@ -85,7 +86,6 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
         :param controls_subset: pass in a specific set of controls to set up the navigation for (only these controls will be effacted and then can will only be set up to navigate to each other)
         :param control_types: the types of controls to consider for the navigation
         """
-        # type: (bool, bool, bool, bool, typing.Iterable[xbmcgui.Control], typing.Tuple[typing.Any, ...]) -> None
         if controls_subset is None:
             controls = self._controls
         else:
@@ -200,6 +200,7 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
                 control.controlUp(wrap_around_move_up)
 
     def setGeometry(self, width_, height_, rows_, columns_, pos_x=-1, pos_y=-1):
+        # type: (int, int, int, int, int, int) -> None
         """
         Set width, height, Grid layout, and coordinates (optional) for a new control window.
 
@@ -217,7 +218,6 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             self.setGeometry(400, 500, 5, 4)
         """
-        # type: (int, int, int, int, int, int) -> None
         self._width = width_
         self._height = height_
         self.rows = rows_
@@ -230,62 +230,63 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
             self.y = 360 - height_ // 2
 
     def getRows(self):
+        # type: () -> int
         """
         Get grid rows count.
 
         :raises: :class:`AddonWindowError` if a grid has not yet been set.
         """
-        # type: () -> int
         try:
             return self.rows  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Grid layout is not set! Call setGeometry first.')
 
     def getColumns(self):
+        # type: () -> int
         """
         Get grid columns count.
 
         :raises: :class:`AddonWindowError` if a grid has not yet been set.
         """
-        # type: () -> int
         try:
             return self.columns  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Grid layout is not set! Call setGeometry first.')
 
     def getX(self):
-        """Get X coordinate of the top-left corner of the window."""
         # type: () -> int
+        """Get X coordinate of the top-left corner of the window."""
         try:
             return self.x  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Window geometry is not defined! Call setGeometry first.')
 
     def getY(self):
-        """Get Y coordinate of the top-left corner of the window."""
         # type: () -> int
+        """Get Y coordinate of the top-left corner of the window."""
         try:
             return self.y  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Window geometry is not defined! Call setGeometry first.')
 
     def getWindowWidth(self):
-        """Get window width."""
         # type: () -> int
+        """Get window width."""
         try:
             return self._width  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Window geometry is not defined! Call setGeometry first.')
 
     def getWindowHeight(self):
-        """Get window height."""
         # type: () -> int
+        """Get window height."""
         try:
             return self._height  # pytype: disable=attribute-error
         except AttributeError:
             raise AddonWindowError('Window geometry is not defined! Call setGeometry first.')
 
     def connect(self, event, callback):
+        # type: (typing.Union[int, xbmcgui.Control], typing.Callable) -> None
         """
         Connect an event to a function.
 
@@ -319,7 +320,6 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             self.connect(ACTION_NAV_BACK, self.close)
         """
-        # type: (typing.Union[int, xbmcgui.Control], typing.Callable) -> None
 
         if isinstance(event, int):
             connect_list = self._actions_connected
@@ -341,16 +341,17 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
             connect_list.append((event, [callback]))
 
     def connectEventList(self, events, callback):
+        # type: (typing.List[typing.Union[int, xbmcgui.Control]], typing.Callable) -> None
         """
         Connect a list of controls/action codes to a function.
 
         See :meth:`connect` docstring for more info.
         """
-        # type: (typing.List[typing.Union[int, xbmcgui.Control]], typing.Callable) -> None
         for event in events:
             self.connect(event, callback)
 
     def disconnect(self, event, callback=None):
+        # type: (typing.Union[int, xbmcgui.Control], typing.Callable) -> None
         """
         Disconnect an event from a function.
 
@@ -369,7 +370,6 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             self.disconnect(ACTION_NAV_BACK)
         """
-        # type: (typing.Union[int, xbmcgui.Control], typing.Callable) -> None
         if isinstance(event, int):
             event_list = self._actions_connected
         else:
@@ -395,6 +395,7 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
         raise AddonWindowError('The action or control %s is not connected!' % str(event))
 
     def disconnectEventList(self, events, callback=None):
+        # type: (typing.Iterable[typing.Union[int, xbmcgui.Control]], typing.Callable) -> None
         """
         Disconnect a list of controls/action codes from functions.
 
@@ -405,17 +406,16 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
         :raises: :class:`AddonWindowError` if at least one event in the list
             is not connected to any function.
         """
-        # type: (typing.Iterable[typing.Union[int, xbmcgui.Control]], typing.Callable) -> None
         for event in events:
             self.disconnect(event, callback)
 
     def _executeConnected(self, event, connected_list):
+        # type: (typing.Union[int, xbmcgui.Control], typing.List[typing.Tuple[typing.Union[int, xbmcgui.Control], typing.List[typing.Callable]]]) -> None
         """
         Execute a connected event (an action or a control).
 
         This is a helper method not to be called directly.
         """
-        # type: (typing.Union[int, xbmcgui.Control], typing.List[typing.Tuple[typing.Union[int, xbmcgui.Control], typing.List[typing.Callable]]]) -> None
         for item in connected_list:
             if item[0] == event:
                 for callback in item[1]:
@@ -423,6 +423,7 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
                 break
 
     def setAnimation(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Set animation for control
 
@@ -442,7 +443,6 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
                 control.setAnimations([('WindowOpen', 'effect=fade start=0 end=100 time=1000',),
                                         ('WindowClose', 'effect=fade start=100 end=0 time=1000',)])
         """
-        # type: (xbmcgui.Control) -> None
         pass
 
     def setFocus(self, control):
@@ -454,16 +454,17 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
             self._XBMCWindowClass.setFocus(self, control)
 
     def onFocus(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Catch focused controls.
 
         :param control: is an instance of :class:`xbmcgui.Control` class.
         """
-        # type: (xbmcgui.Control) -> None
         if hasattr(control, '_focusedCallback'):
             control._focusedCallback()
 
     def addControl(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Wrapper for xbmcgui.Window.addControl.
 
@@ -476,11 +477,11 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             window.addControls(label)
         """
-        # type: (xbmcgui.Control) -> None
         self._controls.append(control)
         self._XBMCWindowClass.addControl(self, control)
 
     def addControls(self, controls):
+        # type: (typing.Iterable[xbmcgui.Control]) -> None
         """
         Wrapper for xbmcgui.Window.addControls.
 
@@ -493,13 +494,13 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             window.addControls([label, button])
         """
-        # type: (typing.Iterable[xbmcgui.Control]) -> None
         # addControls is not directly available on XBMC4XBOX
         # so this implementation is the most portable
         for control in controls:
             self.addControl(control)
 
     def removeControl(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Remove a control from the window grid layout.
 
@@ -509,12 +510,12 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             self.removeControl(self.label)
         """
-        # type: (xbmcgui.Control) -> None
         if hasattr(control, "_removedCallback"):
             control._removedCallback(self)
         self._XBMCWindowClass.removeControl(self, control)
 
     def removeControls(self, controls):
+        # type: (typing.Iterable[xbmcgui.Control]) -> None
         """
         Remove multiple controls from the window grid layout.
 
@@ -524,17 +525,16 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
 
             self.removeControl(self.label)
         """
-        # type: (typing.Iterable[xbmcgui.Control]) -> None
         for control in controls:
             self.removeControl(control)
 
     def onAction(self, action):
+        # type: (xbmcgui.Action) -> None
         """
         Catch button actions.
 
         :param action: an instance of :class:`xbmcgui.Action` class.
         """
-        # type: (xbmcgui.Action) -> None
         if action == ACTION_PREVIOUS_MENU:
             self.close()  # pytype: disable=attribute-error
         # On control is not called on XBMC4XBOX for subclasses of the built in
@@ -548,12 +548,12 @@ class AbstractWindow(AbstractGrid if _XBMC4XBOX else with_metaclass(ABCMeta, Abs
             self._executeConnected(action, self._actions_connected)
 
     def onControl(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Catch activated controls.
 
         :param control: is an instance of :class:`xbmcgui.Control` class.
         """
-        # type: (xbmcgui.Control) -> None
         self._executeConnected(control, self._controls_connected)
 
 
@@ -575,18 +575,18 @@ class AddonWindow(AbstractWindow):
     """
 
     def __init__(self, title=''):
-        """Constructor method."""
         # type: (str) -> None
+        """Constructor method."""
         super(AddonWindow, self).__init__()
         self._setFrame(title)
 
     def onControl(self, control):
+        # type: (xbmcgui.Control) -> None
         """
         Catch activated controls.
 
         :param control: is an instance of :class:`xbmcgui.Control` class.
         """
-        # type: (xbmcgui.Control) -> None
         if (hasattr(self, 'window_close_button') and
                 control.getId() == self.window_close_button.getId()):
             self.close()  # pytype: disable=attribute-error
@@ -594,6 +594,7 @@ class AddonWindow(AbstractWindow):
             super(AddonWindow, self).onControl(control)
 
     def _setFrame(self, title):
+        # type: (str) -> None
         """
         Set window frame
 
@@ -602,7 +603,6 @@ class AddonWindow(AbstractWindow):
 
         This is a helper method not to be called directly.
         """
-        # type: (str) -> None
         # Window background image
         self.background_img = skin.background_img
         # Background for a window header
@@ -624,6 +624,7 @@ class AddonWindow(AbstractWindow):
         self.setAnimation(self.window_close_button)
 
     def setGeometry(self, width_, height_, rows_, columns_, pos_x=-1, pos_y=-1, padding=5):
+        # type: (int, int, int, int, int, int, int) -> None
         """
         Set width, height, Grid layout, and coordinates (optional) for a new control window.
 
@@ -643,7 +644,6 @@ class AddonWindow(AbstractWindow):
 
             self.setGeometry(400, 500, 5, 4)
         """
-        # type: (int, int, int, int, int, int, int) -> None
         self.win_padding = padding
         super(AddonWindow, self).setGeometry(width_, height_, rows_, columns_, pos_x, pos_y)
         self.background.setPosition(self.x, self.y)
@@ -660,12 +660,12 @@ class AddonWindow(AbstractWindow):
                                              self.y + skin.y_margin + skin.close_btn_y_offset)
 
     def _raiseSetGeometryNotCalledError(self):
+        # type: () -> None
         """
         Helper method that raises an AddonWindowError  that states that setGeometry needs to be called. Used by methods
         that will fail if the window geometry is not defined.
         :raises AddonWindowError
         """
-        # type: () -> None
         raise AddonWindowError('Window geometry is not defined! Call setGeometry first.')
 
     def getGridX(self):
@@ -701,6 +701,7 @@ class AddonWindow(AbstractWindow):
         return val - skin.header_height - skin.title_back_y_shift - 2 * skin.y_margin
 
     def setWindowTitle(self, title=''):
+        # type: (str) -> None
         """
         Set window title.
 
@@ -711,12 +712,11 @@ class AddonWindow(AbstractWindow):
 
             self.setWindowTitle('My Cool Addon')
         """
-        # type: (str) -> None
         self.title_bar.setLabel(title)
 
     def getWindowTitle(self):
-        """Get window title."""
         # type: () -> str
+        """Get window title."""
         return self.title_bar.getLabel()
 
 
@@ -766,10 +766,10 @@ class AddonFullWindow(AddonWindow, xbmcgui.Window):
         return super(AddonFullWindow, cls).__new__(cls, *args, **kwargs)
 
     def _setFrame(self, title):
+        # type: (str) -> None
         """
         Set the image for for the fullscreen background.
         """
-        # type: (str) -> None
         # Image for the fullscreen background.
         self.main_bg_img = skin.main_bg_img
         # Fullscreen background image control.
@@ -778,6 +778,7 @@ class AddonFullWindow(AddonWindow, xbmcgui.Window):
         super(AddonFullWindow, self)._setFrame(title)
 
     def setBackground(self, image=''):
+        # type: (str) -> None
         """
         Set the main bacground to an image file.
 
@@ -787,7 +788,6 @@ class AddonFullWindow(AddonWindow, xbmcgui.Window):
 
             self.setBackground('/images/bacground.png')
         """
-        # type: (str) -> None
         self.main_bg.setImage(image)
 
 


### PR DESCRIPTION
The type hints are meant to go right after a function signature and previously I had put them after the docstring