### PR TITLE
Docs update

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -1,7 +1,9 @@
 Using PyXBMCt In Your Addon
 ===========================
 
-PyXBMCt addon module is included in the official Kodi (XBMC) repo. So to use it, first you need to add
+First, you need to make sure you have script.module.pyxbmct actually installed on your PC for development purposes. You need to either install your addon from a ZIP so that all the dependencies will be installed with it, or install another addon that have PyXBMCt as a dependency, like TVmaze Scrobbler. You can remove the additional addon afterwards if you want.
+
+PyXBMCt addon module is included in the official Kodi (XBMC) repo. So to use it, you need to add
 the following string into ``<requires>`` section of your ``addon.xml``::
 
     <import addon="script.module.pyxbmct" />


### PR DESCRIPTION
I noticed Roman responded to a question on the Kodi forum saying that in order to develop with pyxbmct you need to have it's dependencies. I ran into this same issue so I updated the docs to reflect this.